### PR TITLE
deployment in ROOT context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     environment:
       POSTGRES_DB_HOST: postgres
       DSPACE_WEBAPPS: "jspui xmlui rest oai rdf sword swordv2"
-      CATALINA_OPTS: "-Dorg.apache.el.parser.SKIP_IDENTIFIER_CHECK=true -Xmx2048m -Xms2048m -XX:MaxPermSize=512m"
+      CATALINA_OPTS: "-Dorg.apache.el.parser.SKIP_IDENTIFIER_CHECK=true -Xmx4096m -Xms2048m -XX:MaxPermSize=1024m"
       ADMIN_EMAIL: admin@example.com
       ADMIN_PASSWD: admin123
       # ADMIN_FIRSTNAME: DSpace

--- a/fs/usr/local/bin/start-dspace
+++ b/fs/usr/local/bin/start-dspace
@@ -30,5 +30,10 @@ if [ -n "$DSPACE_WEBAPPS" ]; then
     done
 fi
 
+# Deploy to jspui to ROOT context to avoid jspui path
+if [ ! -d ${CATALINA_HOME}/webapps/ROOT ]; then
+    ln -s ${CATALINA_HOME}/webapps/jspui ${CATALINA_HOME}/webapps/ROOT
+fi
+
 # Start Tomcat
 exec catalina.sh run


### PR DESCRIPTION
This PR deploys the jspui webapp as root, so that the container user does not have to set the patch to /jspui (this will display a white page only by default).

Apparently this needs much more memory; on my test system I was not able to deploy the webapps with ROOT with 2 GB. Raising the memory limit to 4 GB solved this issue.